### PR TITLE
Hotfix for sort-keys issue, and small merge conflict bug

### DIFF
--- a/src/screens/runPlan/ListMode/RunPlanListScreen.tsx
+++ b/src/screens/runPlan/ListMode/RunPlanListScreen.tsx
@@ -19,11 +19,7 @@ export class RunPlanListScreen extends React.PureComponent<
     return (
       <View style={styles.container}>
         <FullScreenTemplate padded darkBackground>
-<<<<<<< HEAD:src/screens/runPlan/runPlanList/RunPlanListScreen.tsx
-          <PlanItemList
-=======
           <PlanElementList
->>>>>>> master:src/screens/runPlan/ListMode/RunPlanListScreen.tsx
             student={student}
             itemParent={itemParent}
             onGoBack={() => null}

--- a/src/styles/typography.tsx
+++ b/src/styles/typography.tsx
@@ -7,30 +7,7 @@ import { StyleSheet } from 'react-native';
 
 import { fonts } from './fonts';
 
-interface TypographyEntry {
-  fontFamily: string;
-  fontSize: number;
-  fontWeight?: string;
-  letterSpacing: number;
-}
-
-interface Typography {
-  headline1: TypographyEntry;
-  headline2: TypographyEntry;
-  headline3: TypographyEntry;
-  headline4: TypographyEntry;
-  headline5: TypographyEntry;
-  headline6: TypographyEntry;
-  subtitle1: TypographyEntry;
-  subtitle2: TypographyEntry;
-  body1: TypographyEntry;
-  body2: TypographyEntry;
-  button: TypographyEntry;
-  caption: TypographyEntry;
-  overline: TypographyEntry;
-}
-
-export const typography: Typography = StyleSheet.create({
+export const typography = StyleSheet.create({
   headline1: {
     fontFamily: fonts.sansSerif.light,
     fontSize: 96,

--- a/tslint.json
+++ b/tslint.json
@@ -10,10 +10,7 @@
     "jsx-no-lambda": [false],
     // TODO This rule is really usefull during merge conflicts as in consuming our code APIs
     // To fix it we need more typing in the codebase
-    "object-literal-sort-keys": {
-      "severity": "warning",
-      "options": ["match-declaration-order", "shorthand-first"]
-    },
+    "object-literal-sort-keys": false,
     // TODO allowing to import implicit dependencies may cause to commit the leftovers from developer experiments
     // Removing this rule will need to fix current submodule architecture for 'services', 'screens', etc.
     "no-implicit-dependencies": false


### PR DESCRIPTION
I need to dig deeper before I will type the typography StyleSheet. I see now why this rule is blocked.