### PR TITLE
Remove tests stage from the `pre-commit` and `pre-push` stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:coverage": "yarn test --coverage",
     "test": "jest --env=jsdom --updateSnapshot --silent",
     "typescript-check": "tsc --noEmit",
-    "pre-commit": "lint-staged && yarn test"
+    "pre-commit": "lint-staged"
   },
   "dependencies": {
     "formik": "^1.5.7",
@@ -62,14 +62,13 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run pre-commit",
-      "pre-push": "yarn test:coverage"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {
     "*.{ts,tsx}": [
       "prettier --write",
-      "tslint --fix",
+      "tslint",
       "git add"
     ]
   }


### PR DESCRIPTION
I propose to remove the test checks from the `pre-commit` and `pre-push` stages. This is very slow process and unnecessary on commit phase:
-- It encourages devs to commit with `--no-verify` flag the WiP commits.
-- It takes a few minutes for the code that is badly covered with tests. With proper coverage it will takes to long to check it on every commit.

In addition i propose to add a CI/CD with travis-ci or CircleCI which will handle such things:
-- unit testing
-- code coverage check
-- tslint/prettier check to double check `--no-verify`

Let me know what do you think about that.