### PR TITLE
#174: Hide search button on on students search when search value is empty, change searched list to be sorted

### DIFF
--- a/src/screens/studentsListSearch/FilterableStudentsList.tsx
+++ b/src/screens/studentsListSearch/FilterableStudentsList.tsx
@@ -9,7 +9,17 @@ interface Props {
 }
 
 export const FilterableStudentsList: SFC<Props> = ({ students, searchQuery }) => {
-  const filteredStudents: Student[] = students.filter(student => student.name.match(new RegExp(searchQuery, 'i')));
+  const filteredStudents: Student[] = students
+    .filter(student => student.name.match(new RegExp(searchQuery, 'i')))
+    .sort((student1: Student, student2: Student) => {
+      if (student1.name < student2.name) {
+        return -1;
+      }
+      if (student1.name > student2.name) {
+        return 1;
+      }
+      return 0;
+    });
 
   return (
     <View>

--- a/src/screens/studentsListSearch/StudentsListSearchScreen.tsx
+++ b/src/screens/studentsListSearch/StudentsListSearchScreen.tsx
@@ -38,9 +38,13 @@ export class StudentsListSearchScreen extends React.PureComponent<Props, State> 
       value={this.state.searchQuery}
     />
   );
-  renderClearInputButton = () => (
-    <IconButton type="material" name="close" size={24} color={palette.textBody} onPress={this.onSearchInputClear} />
-  );
+
+  renderClearInputButton = () =>
+    this.state.searchQuery === '' ? (
+      <></>
+    ) : (
+      <IconButton type="material" name="close" size={24} color={palette.textBody} onPress={this.onSearchInputClear} />
+    );
 
   render() {
     const { navigation } = this.props;


### PR DESCRIPTION
The PR resolves part of #174 , search button is hidden if search value is empty and searched students are sorted by name. I did not implement highlighting part of searched text on list.

- [x] X button should clear search
- [x] X button is invisible when there is nothing in the search input
- [x] The students list is sorted alphabetically
- [ ] highlight a matching part of a found text
