### PR TITLE
#247: Set empty plan number to 0

### DIFF
--- a/src/locale/pl.ts
+++ b/src/locale/pl.ts
@@ -1,7 +1,7 @@
 const translations = {
   planActivity: {
     planNamePlaceholder: 'Wpisz nazwę planu',
-    newPlan: 'Nowy Plan',
+    newPlan: 'Nowy Plan #',
     shuffleTasks: 'Tasuj zadania',
   },
   common: {

--- a/src/screens/studentPlanList/EmptyStudentPlans.tsx
+++ b/src/screens/studentPlanList/EmptyStudentPlans.tsx
@@ -16,6 +16,7 @@ export class EmptyStudentPlans extends React.PureComponent<NavigationInjectedPro
 
     this.props.navigation.navigate(Route.PlanActivity, {
       student,
+      numberPlan: 0,
     });
   };
 


### PR DESCRIPTION
Set default plan number to 0 when student does not have any plan yet to avoid undefined in first plan name